### PR TITLE
InvalidRequestException in ProvisioningImp.getGroupByName and ProvisioningImp.getDistributionListByName

### DIFF
--- a/src/java/org/openzal/zal/Provisioning.java
+++ b/src/java/org/openzal/zal/Provisioning.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.openzal.zal.exceptions.NoSuchAccountException;
 import org.openzal.zal.exceptions.NoSuchGrantException;
+import org.openzal.zal.exceptions.NoSuchGroupException;
 import org.openzal.zal.exceptions.UnableToFindDistributionListException;
 import org.openzal.zal.exceptions.ZimbraException;
 import org.openzal.zal.lib.Filter;
@@ -372,9 +373,13 @@ public interface Provisioning
 
   long getLastLogonTimestampFrequency();
 
-  Group assertGroupById(String groupId);
+  @NotNull
+  Group assertGroupById(String groupId)
+    throws NoSuchGroupException;
 
-  Group assertGroupByName(String groupName);
+  @NotNull
+  Group assertGroupByName(String groupName)
+    throws NoSuchGroupException;
 
   class CountAccountByCos
   {

--- a/src/java/org/openzal/zal/ProvisioningImp.java
+++ b/src/java/org/openzal/zal/ProvisioningImp.java
@@ -349,7 +349,14 @@ public class ProvisioningImp implements Provisioning
     }
     catch (com.zimbra.common.service.ServiceException e)
     {
-      throw ExceptionWrapper.wrap(e);
+      try
+      {
+        throw ExceptionWrapper.wrap(e);
+      }
+      catch(InvalidRequestException e1)
+      {
+        return null;
+      }
     }
   }
 
@@ -1774,7 +1781,7 @@ public class ProvisioningImp implements Provisioning
         return new Group(group);
       }
     }
-    catch (ServiceException e)
+    catch (com.zimbra.common.service.ServiceException e)
     {
       throw ExceptionWrapper.wrap(e);
     }
@@ -1783,7 +1790,7 @@ public class ProvisioningImp implements Provisioning
   @Override
   @Nullable
   public Group getGroupByName(String dlStr)
-    throws ZimbraException
+    throws NoSuchGroupException
   {
     try
     {
@@ -1797,9 +1804,16 @@ public class ProvisioningImp implements Provisioning
         return new Group(group);
       }
     }
-    catch (ServiceException e)
+    catch (com.zimbra.common.service.ServiceException e)
     {
-      throw ExceptionWrapper.wrap(e);
+      try
+      {
+        throw ExceptionWrapper.wrap(e);
+      }
+      catch(InvalidRequestException e1)
+      {
+        return null;
+      }
     }
   }
 
@@ -2206,7 +2220,9 @@ public class ProvisioningImp implements Provisioning
   }
 
   @Override
+  @NotNull
   public Group assertGroupById(String groupId)
+    throws NoSuchGroupException
   {
     Group group = getGroupById(groupId);
     if (group == null)
@@ -2218,7 +2234,9 @@ public class ProvisioningImp implements Provisioning
   }
 
   @Override
+  @NotNull
   public Group assertGroupByName(String groupName)
+    throws NoSuchGroupException
   {
     Group group = getGroupByName(groupName);
     if (group == null)


### PR DESCRIPTION
- Fixed small bug in ProvisioningImp.getDistributionListByName and ProvisioningImp.getGroupByName  that throw an InvalidRequestException if the name is not an email