### PR TITLE
NullPointerException on MailboxSessionProxy

### DIFF
--- a/src/java/org/openzal/zal/MailboxSessionProxy.java
+++ b/src/java/org/openzal/zal/MailboxSessionProxy.java
@@ -200,7 +200,7 @@ public class MailboxSessionProxy
         for( PendingModifications.ModificationKey mod : ((Map<PendingModifications.ModificationKey, PendingModifications.Change>) pns.modified).keySet() )
         {
        /* $elseif ZimbraX == 0 $
-        for( PendingModifications.ModificationKey mod : pns.created.keySet() )
+        for( PendingModifications.ModificationKey mod : pns.modified.keySet() )
         {
         /* $endif $ */
        /* $if ZimbraX == 0 $ */


### PR DESCRIPTION
Fixed a wrong use of PendingModification in MailboxSessionProxy for below version of Zimbra 8.8.2