### PR TITLE
2FA attributes not restored

### DIFF
--- a/src/java/org/openzal/zal/Entry.java
+++ b/src/java/org/openzal/zal/Entry.java
@@ -126,9 +126,13 @@ public abstract class Entry
 
   public void modify(Map<String, Object> attrs)
   {
+    modify(attrs, true);
+  }
+  public void modify(Map<String, Object> attrs, boolean checkImmutable)
+  {
     try
     {
-      mEntry.getProvisioning().modifyAttrs(mEntry, attrs);
+      mEntry.getProvisioning().modifyAttrs(mEntry, attrs, checkImmutable);
     }
     catch (ServiceException e)
     {

--- a/src/java/org/openzal/zal/ProvisioningImp.java
+++ b/src/java/org/openzal/zal/ProvisioningImp.java
@@ -76,9 +76,17 @@ public class ProvisioningImp implements Provisioning
   /* $if ZimbraVersion >= 8.7.0 $ */
   public static String A_zimbraMaxAppSpecificPasswords                        = com.zimbra.cs.account.Provisioning.A_zimbraMaxAppSpecificPasswords;
   public static String A_zimbraZimletUserPropertiesMaxNumEntries              = com.zimbra.cs.account.Provisioning.A_zimbraZimletUserPropertiesMaxNumEntries;
+  public static String A_zimbraTwoFactorAuthEnabled                           = com.zimbra.cs.account.Provisioning.A_zimbraTwoFactorAuthEnabled;
+  public static String A_zimbraTwoFactorAuthScratchCodes                      = com.zimbra.cs.account.Provisioning.A_zimbraTwoFactorAuthScratchCodes;
+  public static String A_zimbraTwoFactorAuthSecret                            = com.zimbra.cs.account.Provisioning.A_zimbraTwoFactorAuthSecret;
+  public static String A_zimbraAppSpecificPassword                            = com.zimbra.cs.account.Provisioning.A_zimbraAppSpecificPassword;
   /* $else $
   public static String A_zimbraMaxAppSpecificPasswords                        = "";
   public static String A_zimbraZimletUserPropertiesMaxNumEntries              = "";
+  public static String A_zimbraTwoFactorAuthEnabled                           = "";
+  public static String A_zimbraTwoFactorAuthScratchCodes                      = "";
+  public static String A_zimbraTwoFactorAuthSecret                            = "";
+  public static String A_zimbraAppSpecificPassword                            = "";
   /* $endif $ */
 
   public static String A_zimbraIsACLGroup                                           = com.zimbra.cs.account.Provisioning.A_zimbraIsACLGroup;


### PR DESCRIPTION
I've added 2FA constants to ProvisioningImpl for handler attributes on accounts.
I've modified method modify for accepting a new param checkImmutable to bypass this control on 2FA attributes on restore