### PR TITLE
Avoid decompress and recompress digest if zimbra blob is already compressed

### DIFF
--- a/src/java/org/openzal/zal/Blob.java
+++ b/src/java/org/openzal/zal/Blob.java
@@ -39,5 +39,6 @@ public interface Blob
   Blob setDigest(String digest);
   Blob setSize(long size);
   long getStoredFileSize() throws IOException;
+  boolean isCompressed() throws IOException;
 }
 

--- a/src/java/org/openzal/zal/BlobWrap.java
+++ b/src/java/org/openzal/zal/BlobWrap.java
@@ -138,6 +138,13 @@ public class BlobWrap implements Blob
     return mBlob.getFile().length();
   }
 
+  @Override
+  public boolean isCompressed()
+    throws IOException
+  {
+    return mBlob.isCompressed();
+  }
+
   public String getKey()
   {
     return mBlob.getPath();

--- a/src/java/org/openzal/zal/MailboxBlobWrap.java
+++ b/src/java/org/openzal/zal/MailboxBlobWrap.java
@@ -104,6 +104,13 @@ public class MailboxBlobWrap implements MailboxBlob
   }
 
   @Override
+  public boolean isCompressed()
+    throws IOException
+  {
+    return mMailboxBlob.getLocalBlob().isCompressed();
+  }
+
+  @Override
   public Blob getLocalBlob()
   {
     try

--- a/src/java/org/openzal/zal/StagedBlobWrap.java
+++ b/src/java/org/openzal/zal/StagedBlobWrap.java
@@ -93,6 +93,13 @@ public class StagedBlobWrap<S extends Blob> implements StagedBlob
   }
 
   @Override
+  public boolean isCompressed()
+    throws IOException
+  {
+    return false;
+  }
+
+  @Override
   public void renameTo(String newPath) throws IOException
   {
     wrapZimbraObject(mStagedBlob).renameTo(newPath);

--- a/src/java/org/openzal/zal/ZalBlob.java
+++ b/src/java/org/openzal/zal/ZalBlob.java
@@ -146,4 +146,11 @@ public class ZalBlob implements Blob
   {
     return mFile.length();
   }
+
+  @Override
+  public boolean isCompressed()
+    throws IOException
+  {
+    return false;
+  }
 }

--- a/src/java/org/openzal/zal/ZalMailboxBlob.java
+++ b/src/java/org/openzal/zal/ZalMailboxBlob.java
@@ -135,4 +135,11 @@ public class ZalMailboxBlob extends ZalBlob implements MailboxBlob
   {
     return this;
   }
+
+  @Override
+  public boolean isCompressed()
+    throws IOException
+  {
+    return mBlob.isCompressed();
+  }
 }


### PR DESCRIPTION
Added isCompressed method to blob wrapper for passing information from zimbra blob