### PR TITLE
[MOB-68] misuse of isaccountexternal

### DIFF
--- a/src/java/org/openzal/zal/Account.java
+++ b/src/java/org/openzal/zal/Account.java
@@ -252,6 +252,8 @@ public class Account extends Entry
     }
   }
 
+  // !mAccount.getServer().mailTransportMatches(mAccount.getAttr("zimbraMailTransport"));
+  // Probably you want isIsExternalVirtualAccount
   public boolean isAccountExternal()
   {
     try

--- a/src/java/org/openzal/zal/ProvisioningImp.java
+++ b/src/java/org/openzal/zal/ProvisioningImp.java
@@ -136,6 +136,10 @@ public class ProvisioningImp implements Provisioning
   public static String A_zimbraMailOutgoingSieveScript                              = com.zimbra.cs.account.Provisioning.A_zimbraMailOutgoingSieveScript;
   public static String A_zimbraMailTrustedSenderListMaxNumEntries                   = com.zimbra.cs.account.Provisioning.A_zimbraMailTrustedSenderListMaxNumEntries;
   public static String A_zimbraIsExternalVirtualAccount                             = com.zimbra.cs.account.Provisioning.A_zimbraIsExternalVirtualAccount;
+  public static String A_zimbraIsSystemAccount                                      = com.zimbra.cs.account.Provisioning.A_zimbraIsSystemAccount;
+  public static String A_zimbraIsSystemResource                                     = com.zimbra.cs.account.Provisioning.A_zimbraIsSystemResource;
+  public static String A_zimbraCalResType                                           = com.zimbra.cs.account.Provisioning.A_zimbraCalResType;
+
 
 /* $if ZimbraVersion >= 8.5.0 $ */
   public static String A_zimbraAuthTokens                                     = com.zimbra.cs.account.Provisioning.A_zimbraAuthTokens;

--- a/src/java/org/openzal/zal/ProvisioningImp.java
+++ b/src/java/org/openzal/zal/ProvisioningImp.java
@@ -139,6 +139,11 @@ public class ProvisioningImp implements Provisioning
   public static String A_zimbraIsSystemAccount                                      = com.zimbra.cs.account.Provisioning.A_zimbraIsSystemAccount;
   public static String A_zimbraIsSystemResource                                     = com.zimbra.cs.account.Provisioning.A_zimbraIsSystemResource;
   public static String A_zimbraCalResType                                           = com.zimbra.cs.account.Provisioning.A_zimbraCalResType;
+  /* $if ZimbraVersion >= 8.8.10 $ */
+  public static String A_zimbraPrefDefaultCalendarId                                = com.zimbra.cs.account.Provisioning.A_zimbraPrefDefaultCalendarId;
+/* $else$
+  public static String A_zimbraPrefDefaultCalendarId                                = "";
+/* $endif$ */
 
 
 /* $if ZimbraVersion >= 8.5.0 $ */


### PR DESCRIPTION
- Replaced all uses of Account.isAccountExternal() with Account.isIsExternalVirtualAccount()
- Added some String constants in Provisioning: A_zimbraIsSystemAccount, A_zimbraIsSystemResource, A_zimbraCalResType and replaced all hardcoded strings