### PR TITLE
[MOB-204] Explicit cast to Zimbra Account

### DIFF
--- a/src/java/org/openzal/zal/Utils.java
+++ b/src/java/org/openzal/zal/Utils.java
@@ -279,7 +279,7 @@ public abstract class Utils
   {
     try
     {
-      return JMSession.getSmtpSession(null);
+      return JMSession.getSmtpSession((com.zimbra.cs.account.Account) null);
     }
     catch (MessagingException e)
     {


### PR DESCRIPTION
Fixed possible RuntimeException when calling Utils::getSmtpSession on Zimbra version > 8.8.15.p9