### PR TITLE
chore: update carbonio and openzal version

### DIFF
--- a/packages/PKGBUILD
+++ b/packages/PKGBUILD
@@ -3,7 +3,7 @@ targets=(
   "ubuntu"
 )
 pkgname="carbonio-zal"
-pkgver="3.10.5"
+pkgver="3.10.7"
 pkgrel="1"
 pkgdesc="Carbonio extras"
 pkgdesclong=(

--- a/packages/PKGBUILD
+++ b/packages/PKGBUILD
@@ -3,7 +3,7 @@ targets=(
   "ubuntu"
 )
 pkgname="carbonio-zal"
-pkgver="3.10.4"
+pkgver="3.10.5"
 pkgrel="1"
 pkgdesc="Carbonio extras"
 pkgdesclong=(

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.openzal</groupId>
   <artifactId>zal</artifactId>
-  <version>3.10.5</version>
+  <version>3.10.7</version>
   <packaging>jar</packaging>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.openzal</groupId>
   <artifactId>zal</artifactId>
-  <version>3.10.4</version>
+  <version>3.10.5</version>
   <packaging>jar</packaging>
 
   <repositories>
@@ -89,7 +89,7 @@
   </distributionManagement>
 
   <properties>
-    <zimbra.version>22.3.0</zimbra.version>
+    <zimbra.version>22.3.1</zimbra.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson.version>2.8.11</jackson.version>
     <jfreechart.version>1.0.15</jfreechart.version>


### PR DESCRIPTION
update carbonio appserver target to 22.3.1 and OpenZAL version to 3.10.5