### PR TITLE
chore(CI): update ubuntu pacur agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,10 +102,10 @@ pipeline {
               }
               stage('pacur') {
                   parallel {
-                      stage('Ubuntu 18.04') {
+                      stage('Ubuntu 20.04') {
                           agent {
                               node {
-                                  label 'pacur-agent-ubuntu-18.04-v1'
+                                  label 'pacur-agent-ubuntu-20.04-v1'
                               }
                           }
                           steps {


### PR DESCRIPTION
because this repo contains no native binaries, let's update the pacur ubuntu agent to the focal one