### PR TITLE
added missing methods for handling PUT, DELETE and PATCH HTTP requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.openzal</groupId>
   <artifactId>zal</artifactId>
-  <version>3.19.0</version>
+  <version>3.19.1</version>
   <packaging>jar</packaging>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.openzal</groupId>
   <artifactId>zal</artifactId>
-  <version>3.19.1</version>
+  <version>3.19.2</version>
   <packaging>jar</packaging>
 
   <repositories>

--- a/src/java/org/openzal/zal/http/HttpHandler.java
+++ b/src/java/org/openzal/zal/http/HttpHandler.java
@@ -36,5 +36,14 @@ public interface HttpHandler
   public void doOptions(HttpServletRequest req, HttpServletResponse resp)
     throws ServletException, IOException;
 
+  public void doPut(HttpServletRequest req, HttpServletResponse resp)
+    throws ServletException, IOException;
+
+  public void doDelete(HttpServletRequest req, HttpServletResponse resp)
+    throws ServletException, IOException;
+
+  public void doPatch(HttpServletRequest req, HttpServletResponse resp)
+    throws ServletException, IOException;
+
   public String getPath();
 }

--- a/src/java/org/openzal/zal/http/InternalHttpHandler.java
+++ b/src/java/org/openzal/zal/http/InternalHttpHandler.java
@@ -51,9 +51,27 @@ class InternalHttpHandler extends ExtensionHttpHandler
     mHttpHandler.doGet(req, resp);
   }
 
-
+  @Override
   public void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException
   {
     mHttpHandler.doPost(req, resp);
+  }
+
+  @Override
+  public void doPut(HttpServletRequest req, HttpServletResponse resp)
+    throws IOException, ServletException {
+    mHttpHandler.doPut(req, resp);
+  }
+
+  @Override
+  public void doDelete(HttpServletRequest req, HttpServletResponse resp)
+    throws IOException, ServletException {
+    mHttpHandler.doDelete(req, resp);
+  }
+
+  @Override
+  public void doPatch(HttpServletRequest req, HttpServletResponse resp)
+    throws IOException, ServletException {
+    mHttpHandler.doPatch(req, resp);
   }
 }


### PR DESCRIPTION
The HttpHandler interface and InternalHttpHandler do not handle PUT, DELETE or PATCH requests.
With this PR I am adding support for them.
