### PR TITLE
Add a flag to deploy the current jars to artifactory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
                 mvnCmd("deploy -DskipTests -Pdev")
             }
         }
-        stage('Publish tagged version') {
+        stage('Publish version') {
             when {
                 anyOf {
                     expression { params.PUBLISH_TO_ARTIFACTORY == true }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
     }
     parameters {
         booleanParam defaultValue: false, description: 'Whether to upload the packages in playground repositories', name: 'PLAYGROUND'
+        booleanParam defaultValue: false, description: 'Publish artifact to artifactory', name: 'PUBLISH_TO_ARTIFACTORY'
     }
     environment {
         JAVA_OPTS="-Dfile.encoding=UTF8"
@@ -90,6 +91,7 @@ pipeline {
         stage('Publish tagged version') {
             when {
                 anyOf {
+                    expression { params.PUBLISH_TO_ARTIFACTORY == true }
                     buildingTag()
                 }
             }


### PR DESCRIPTION
The flag PUBLISH_TO_ARTIFACTORY has been introduced because creating a tag on the project is going to publish jars and release os packages. Using this flag, it is possible to publish openzal jar to artifactory without releasing new os packages. This happen to be usefull during the development phase,