### PR TITLE
fix: removed zimbra.mobile_devices from the list of zimbra tables

### DIFF
--- a/src/main/java/org/openzal/zal/MailboxManagerImp.java
+++ b/src/main/java/org/openzal/zal/MailboxManagerImp.java
@@ -71,7 +71,6 @@ public class MailboxManagerImp implements MailboxManager
                                            "revision_dumpster",
                                            "zimbra.mailbox",
                                            "zimbra.mailbox_metadata",
-                                           "zimbra.mobile_devices",
                                            "zimbra.out_of_office",
                                            "zimbra.pending_acl_push",
                                            "zimbra.scheduled_task"


### PR DESCRIPTION
The table has been removed from the database with this commit: https://github.com/zextras/carbonio-db-conf/commit/e5faf503acf2f42cd8f7300827308cd9b71958a3